### PR TITLE
Validate dictionary args only if persistence is required

### DIFF
--- a/Sources/SwiftQueue/Job.swift
+++ b/Sources/SwiftQueue/Job.swift
@@ -97,7 +97,6 @@ public final class JobBuilder {
 
     /// Custom parameters will be forwarded to create method
     public func with(params: [String: Any]) -> Self {
-        assert(JSONSerialization.isValidJSONObject(params))
         info.params = params
         return self
     }
@@ -108,6 +107,11 @@ public final class JobBuilder {
 
     /// Add job to the JobQueue
     public func schedule(manager: SwiftQueueManager) {
+        if info.isPersisted {
+            // Check if we will be able to serialise args
+            assert(JSONSerialization.isValidJSONObject(info.params))
+        }
+
         let queue = manager.getQueue(name: info.group)
         guard let job = queue.createHandler(type: info.type, params: info.params) else {
             return

--- a/Tests/SwiftQueueTests/SwiftQueueBuilderTests.swift
+++ b/Tests/SwiftQueueTests/SwiftQueueBuilderTests.swift
@@ -135,6 +135,17 @@ class SwiftQueueBuilderTests: XCTestCase {
         XCTAssertTrue(NSDictionary(dictionary: params).isEqual(to: jobInfo?.params))
     }
 
+    public func testBuilderWithFreeArgs() {
+        let type = UUID().uuidString
+        let params: [String: Any] = [UUID().uuidString: [UUID().uuidString: self]]
+
+        let creator = TestCreator([type: TestJob()])
+        let manager = SwiftQueueManager(creators: [creator])
+        
+        // No assert expected
+        JobBuilder(type: type).with(params: params).schedule(manager: manager)
+    }
+
     private func toJobInfo(type: String, _ builder: JobBuilder) -> JobInfo? {
         let creator = TestCreator([type: TestJob()])
         let persister = PersisterTracker(key: UUID().uuidString)


### PR DESCRIPTION
PR for issue #60
Allow free args when the persistence is not required.