### PR TITLE
Only accept one creator to avoid having missing handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## [1.6.0](https://github.com/lucas34/SwiftQueue/tree/1.6.0)
 
 #### Breaking Changes
+- Change `JobCreator.create` signature (#94)
+    - Return type is no longer optional
+    - `SwiftQueueManager` only accept 1 single `JobCreator`
+    - This is to avoid unregistered handler or scheduling job with no `JobCreator` associates
+    - The user will have to deal with unknown handler on his side
 - Origin error is now forward to completion block (#88)
 - Change signature of Limit(Int) to Limit(Double)
 

--- a/Sources/SwiftQueue/JobBuilder.swift
+++ b/Sources/SwiftQueue/JobBuilder.swift
@@ -103,9 +103,8 @@ public final class JobBuilder {
         }
 
         let queue = manager.getQueue(queueName: info.group)
-        guard let job = queue.createHandler(type: info.type, params: info.params) else {
-            return
-        }
+        let job = queue.createHandler(type: info.type, params: info.params)
+
         queue.addOperation(build(job: job))
     }
 }

--- a/Sources/SwiftQueue/SqOperation.swift
+++ b/Sources/SwiftQueue/SqOperation.swift
@@ -195,20 +195,18 @@ extension SqOperation: JobResult {
 
 extension SqOperation {
 
-    convenience init?(dictionary: [String: Any], creator: [JobCreator]) {
+    convenience init?(dictionary: [String: Any], creator: JobCreator) {
         guard let info = JobInfo(dictionary: dictionary) else {
             assertionFailure("Unable to un-serialise job")
             return nil
         }
 
-        guard let job = SqOperationQueue.createHandler(creators: creator, type: info.type, params: info.params) else {
-            return nil
-        }
+        let job = creator.create(type: info.type, params: info.params)
 
         self.init(job: job, info: info)
     }
 
-    convenience init?(json: String, creator: [JobCreator]) {
+    convenience init?(json: String, creator: JobCreator) {
         let dict = fromJSON(json) as? [String: Any] ?? [:]
         self.init(dictionary: dict, creator: creator)
     }

--- a/Sources/SwiftQueue/SwiftQueue.swift
+++ b/Sources/SwiftQueue/SwiftQueue.swift
@@ -10,7 +10,7 @@ public protocol JobCreator {
 
     /// method called when a job has be to instantiate
     /// Type as specified in JobBuilder.init(type) and params as JobBuilder.with(params)
-    func create(type: String, params: [String: Any]?) -> Job?
+    func create(type: String, params: [String: Any]?) -> Job
 
 }
 

--- a/Sources/SwiftQueue/SwiftQueueManager.swift
+++ b/Sources/SwiftQueue/SwiftQueueManager.swift
@@ -10,7 +10,7 @@ import Foundation
 /// Creating and instance of this class will automatically un-serialise your jobs and schedule them 
 public final class SwiftQueueManager {
 
-    private let creators: [JobCreator]
+    private let creator: JobCreator
     private let persister: JobPersister?
 
     private var manage = [String: SqOperationQueue]()
@@ -18,20 +18,16 @@ public final class SwiftQueueManager {
     private var isPaused = true
 
     /// Create a new QueueManager with creators to instantiate Job
-    public init(creators: [JobCreator], persister: JobPersister? = nil) {
-        self.creators = creators
+    public init(creator: JobCreator, persister: JobPersister? = nil) {
+        self.creator = creator
         self.persister = persister
 
         if let data = persister {
             for queueName in data.restore() {
-                manage[queueName] = SqOperationQueue(queueName, creators, persister, isPaused)
+                manage[queueName] = SqOperationQueue(queueName, creator, persister, isPaused)
             }
         }
         start()
-    }
-
-    public convenience init(creator: JobCreator, persister: JobPersister? = nil) {
-        self.init(creators: [creator], persister: persister)
     }
 
     /// Jobs queued will run again
@@ -55,7 +51,7 @@ public final class SwiftQueueManager {
     }
 
     private func createQueue(queueName: String) -> SqOperationQueue {
-        let queue = SqOperationQueue(queueName, creators, persister, isPaused)
+        let queue = SqOperationQueue(queueName, creator, persister, isPaused)
         manage[queueName] = queue
         return queue
     }

--- a/Tests/SwiftQueueTests/SwiftQueueBuilderTests.swift
+++ b/Tests/SwiftQueueTests/SwiftQueueBuilderTests.swift
@@ -153,7 +153,7 @@ class SwiftQueueBuilderTests: XCTestCase {
 
         builder.persist(required: true).schedule(manager: manager)
 
-        let actual = SqOperation(json: persister.putData[0], creator: [creator])
+        let actual = SqOperation(json: persister.putData[0], creator: creator)
         return actual?.info
     }
 

--- a/Tests/SwiftQueueTests/SwiftQueueTests.swift
+++ b/Tests/SwiftQueueTests/SwiftQueueTests.swift
@@ -121,7 +121,7 @@ class SwiftQueueManagerTests: XCTestCase {
     }
 
     func testAddOperationNotJobTask() {
-        let queue = SqOperationQueue(UUID().uuidString, [])
+        let queue = SqOperationQueue(UUID().uuidString, TestCreator([:]))
         let operation = Operation()
         queue.addOperation(operation) // Should not crash
     }

--- a/Tests/SwiftQueueTests/TestUtils.swift
+++ b/Tests/SwiftQueueTests/TestUtils.swift
@@ -98,7 +98,8 @@ class TestJob: Job {
         XCTAssertTrue(lastError is JobError, file: file, line: line)
     }
     public func assertError(queueError: SwiftQueueError, file: StaticString = #file, line: UInt = #line) {
-        let base: SwiftQueueError = lastError as! SwiftQueueError
+        XCTAssertTrue(lastError is SwiftQueueError)
+        guard let base: SwiftQueueError = lastError as? SwiftQueueError else { return }
         switch (base, queueError) {
 
         case let (.onRetryCancel(l), .onRetryCancel(r)): XCTAssertEqual(l as? JobError, r as? JobError, file: file, line: line)
@@ -141,14 +142,14 @@ class TestJob: Job {
 }
 
 class TestCreator: JobCreator {
-    private let job: [String: Job]
+    private let job: [String: TestJob]
 
-    public init(_ job: [String: Job]) {
+    public init(_ job: [String: TestJob]) {
         self.job = job
     }
 
-    func create(type: String, params: [String: Any]?) -> Job? {
-        return job[type] as? TestJob
+    func create(type: String, params: [String: Any]?) -> Job {
+        return job[type]!
     }
 }
 


### PR DESCRIPTION
- Change `JobCreator.create` signature (#94)
    - Return type is no longer optional
    - `SwiftQueueManager` only accept 1 single `JobCreator`
    - This is to avoid unregistered handler or scheduling job with no `JobCreator` associates
