### PR TITLE
Added Job Completion Result Value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ DerivedData
 *.hmap
 *.ipa
 *.xcuserstate
+.swiftpm/
 
 # CocoaPods
 #

--- a/Sources/SwiftQueue/SwiftQueue.swift
+++ b/Sources/SwiftQueue/SwiftQueue.swift
@@ -71,21 +71,13 @@ public protocol JobInfoSerializer {
 /// Callback to give result in synchronous or asynchronous job
 public protocol JobResult {
 
-    /// Method callback to notify the completion of your 
+    /// Method callback to notify the completion of your
     func done(_ result: JobCompletion)
 
 }
 
-/// Enum to define possible Job completion values
-public enum JobCompletion {
-
-    /// Job completed successfully
-    case success
-
-    /// Job completed with error
-    case fail(Error)
-
-}
+/// Typealias to define possible Job completion values
+public typealias JobCompletion = Result<Any, Error>
 
 /// Protocol to implement to run a job
 public protocol Job {
@@ -94,7 +86,7 @@ public protocol Job {
     /// Will be called in background thread
     func onRun(callback: JobResult)
 
-    /// Fail has failed with the 
+    /// Fail has failed with the
     /// Will only gets called if the job can be retried
     /// Not applicable for 'ConstraintError'
     /// Not application if the retry(value) is less than 2 which is the case by default
@@ -197,5 +189,7 @@ public enum SwiftQueueError: Error {
 
     /// Job took too long to run
     case timeout
-
+    
+    /// Job couldn't map JobCompletion result
+    case mapping
 }

--- a/Tests/SwiftQueueTests/ConstraintTest+Repeat.swift
+++ b/Tests/SwiftQueueTests/ConstraintTest+Repeat.swift
@@ -53,9 +53,9 @@ class ConstraintTestRepeat: XCTestCase {
         let job = TestJob(retry: .retry(delay: 0)) {
             runCount += 1
             if runCount == runLimit {
-                $0.done(.fail(JobError()))
+                $0.done(.failure(JobError()))
             } else {
-                $0.done(.success)
+                $0.done(.success(true))
             }
         }
 

--- a/Tests/SwiftQueueTests/ConstraintTest+Retry.swift
+++ b/Tests/SwiftQueueTests/ConstraintTest+Retry.swift
@@ -33,9 +33,9 @@ class ConstraintTestRetry: XCTestCase {
         let job = TestJob(retry: .retry(delay: 0)) {
             runCount += 1
             if runCount == runLimit {
-                $0.done(.success)
+                $0.done(.success(true))
             } else {
-                $0.done(.fail(JobError()))
+                $0.done(.failure(JobError()))
             }
         }
 

--- a/Tests/SwiftQueueTests/ConstraintTest+Tag.swift
+++ b/Tests/SwiftQueueTests/ConstraintTest+Tag.swift
@@ -33,7 +33,7 @@ class ConstraintTestTag: XCTestCase {
 
         let (type, job) = (UUID().uuidString, TestJob {
             manager?.cancelOperations(tag: tag)
-            $0.done(.fail(JobError()))
+            $0.done(.failure(JobError()))
         })
 
         let creator = TestCreator([type: job])

--- a/Tests/SwiftQueueTests/LoggerTests.swift
+++ b/Tests/SwiftQueueTests/LoggerTests.swift
@@ -51,7 +51,7 @@ class LoggerTests: XCTestCase {
         XCTAssertEqual(outputs[1], "[SwiftQueue] level=verbose jobId=\(id) message=Job is running")
         XCTAssertEqual(outputs[2], "[SwiftQueue] level=verbose jobId=\(id) message=Job completed successfully")
         XCTAssertEqual(outputs[3], "[SwiftQueue] level=verbose jobId=\(id) message=Job will not run anymore")
-        XCTAssertEqual(outputs[4], "[SwiftQueue] level=verbose jobId=\(id) message=Job is removed from the queue result=success")
+        XCTAssertEqual(outputs[4], "[SwiftQueue] level=verbose jobId=\(id) message=Job is removed from the queue result=success(true)")
     }
 
     func testLoggerLevel() {

--- a/Tests/SwiftQueueTests/SwiftQueueManagerTests.swift
+++ b/Tests/SwiftQueueTests/SwiftQueueManagerTests.swift
@@ -226,7 +226,7 @@ class SwiftQueueManagerTests: XCTestCase {
 
         let (type, job) = (UUID().uuidString, TestJob {
             manager?.cancelAllOperations()
-            $0.done(.fail(JobError()))
+            $0.done(.failure(JobError()))
         })
 
         let creator = TestCreator([type: job])

--- a/Tests/SwiftQueueTests/TestUtils.swift
+++ b/Tests/SwiftQueueTests/TestUtils.swift
@@ -41,7 +41,7 @@ class TestJob: Job {
 
     private var lastError: Error?
 
-    init(retry: RetryConstraint = .retry(delay: 0), onRunCallback: @escaping (JobResult) -> Void = { $0.done(.success) }) {
+    init(retry: RetryConstraint = .retry(delay: 0), onRunCallback: @escaping (JobResult) -> Void = { $0.done(.success(true)) }) {
         self.onRunCallback = onRunCallback
         self.withRetry = retry
     }
@@ -66,7 +66,7 @@ class TestJob: Job {
             onCompletedCount += 1
             onRemoveSemaphore.signal()
 
-        case .fail(let error):
+        case .failure(let error):
             lastError = error
             onCanceledCount += 1
             onRemoveSemaphore.signal()
@@ -145,7 +145,7 @@ class TestJob: Job {
 class TestJobFail: TestJob {
 
     required init(retry: RetryConstraint = .retry(delay: 0), error: Error = JobError()) {
-        super.init(retry: retry) { $0.done(.fail(error))}
+        super.init(retry: retry) { $0.done(.failure(error))}
     }
 
 }


### PR DESCRIPTION
## Discussion
A simple **JobCompletion** success, without any returning value in success cases, can become useless in some contexts or can solve only half of a problem.

## Solution
Converted **JobCompletion** to an alias of swift **Result<Any, Error>** type. "Any" because we are talking about "any" possible result.

## Example of usage:
`Job implementation:`
```
final class UploadFileJob: Job {

    let localFileURL: URL!
    ...
    func onRun(callback: JobResult) {

       self.uploadFileFrom(local: localFileURL) { (remoteUrl, error) in
            if let error = error {
               callback.done(.failure(error))
               return
            }
            callback.done(.success(remoteUrl!))
       }

    }
    ...
}
```

`JobListener implementation:`
<img width="557" alt="screenshot" src="https://user-images.githubusercontent.com/2267843/102019933-d9780200-3d54-11eb-929a-f7f4dddc0995.png">
