### PR TITLE
Fixed Jobs not being removed if persisted

### DIFF
--- a/Sources/SwiftQueue/SqOperationQueue.swift
+++ b/Sources/SwiftQueue/SqOperationQueue.swift
@@ -64,12 +64,11 @@ public final class SqOperationQueue: OperationQueue {
     private func loadSerializedTasks(name: String) {
         persister.restore(queueName: name).compactMap { string -> SqOperation? in
             do {
-                let info = try serializer.deserialize(json: string)
+                var info = try serializer.deserialize(json: string)
                 let job = creator.create(type: info.type, params: info.params)
-                var constraints = info.constraints
-                constraints.append(PersisterConstraint(serializer: serializer, persister: persister))
+                info.constraints.append(PersisterConstraint(serializer: serializer, persister: persister))
 
-                return SqOperation(job, info, logger, listener, dispatchQueue, constraints)
+                return SqOperation(job, info, logger, listener, dispatchQueue, info.constraints)
             } catch let error {
                 logger.log(.error, jobId: "UNKNOWN", message: "Unable to deserialize job error=\(error.localizedDescription)")
                 return nil


### PR DESCRIPTION
If some job was persisted and it failed to complete due to it's constraints or errors, when the user reopen the app and the job manager initializes, if the job completes successfully, it wasn't removed from the persistence, because **loadSerializedTasks** was building an **incomplete SqOperation**.