### PR TITLE
extensible DefaultConstraintMaker for persistence

### DIFF
--- a/Sources/SwiftQueue/ConstraintMaker.swift
+++ b/Sources/SwiftQueue/ConstraintMaker.swift
@@ -30,6 +30,9 @@ public protocol ConstraintMaker {
 
 open class DefaultConstraintMaker: ConstraintMaker {
 
+    //accessible for extension
+    public init() {}
+  
     public func make(from decoder: Decoder) throws -> [CodableConstraint] {
         var constraints: [CodableConstraint] = []
 

--- a/Sources/SwiftQueue/ConstraintMaker.swift
+++ b/Sources/SwiftQueue/ConstraintMaker.swift
@@ -33,7 +33,7 @@ open class DefaultConstraintMaker: ConstraintMaker {
     //accessible for extension
     public init() {}
   
-    public func make(from decoder: Decoder) throws -> [CodableConstraint] {
+    open func make(from decoder: Decoder) throws -> [CodableConstraint] {
         var constraints: [CodableConstraint] = []
 
         #if os(iOS)


### PR DESCRIPTION
Added a custom constraint that needs a custom constraint maker to ensure deserialized job will contain the default constraints and the custom constraint.

The recently "open" DefaultConstraintMaker couldn't be sub-classed without hitting inaccessible initialiser build error.

```
class MyConstraintMaker: DefaultConstraintMaker {
  override public func make(from decoder: Decoder) throws -> [CodableConstraint] {
    var constraints: [CodableConstraint] = try super.make(from: decoder)
    if let constraint = try MyCustomConstraint(from: decoder) { constraints.append(constraint) }
    return constraints
  }
}

queueManager = SwiftQueueManagerBuilder(creator: MyJobCreator())
      .set(serializer: DecodableSerializer(maker: MyConstraintMaker()))
```